### PR TITLE
Add login object name to database GUI

### DIFF
--- a/django_login_history/models.py
+++ b/django_login_history/models.py
@@ -26,6 +26,9 @@ class Login(models.Model):
     city = models.CharField(max_length=50)
     lon = models.FloatField(default=0.0)
     lat = models.FloatField(default=0.0)
+    
+    def __str__(self):
+        return self.user.username + " (" + self.ip + ") at " + str(self.date)
 
 
 


### PR DESCRIPTION
hey, just a quality of life improvement for the admin panel

![image](https://user-images.githubusercontent.com/41923457/83982117-bdb22000-a91b-11ea-81b3-b003975bcd0f.png)

you can now see details about the login, rather than just `Login object (5)`, etc.

happy coding :)